### PR TITLE
Revert "[ci skip][skip ci] ***NO_CI*** Add conda-forge/conda group to maintainers"

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,8 +55,6 @@ about:
 
 extra:
   recipe-maintainers:
-    - conda-forge/conda
-    - conda-forge/conda-build
     - beckermr
     - dbast
     - dholth


### PR DESCRIPTION
Followup to the post merge comments in https://github.com/conda-forge/conda-package-handling-feedstock/pull/71, which only should have been merged with consent of the teams.

This reverts commit 7f40c30b142ee033568bd0d49870d7ecc4902200.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
